### PR TITLE
Update Dockerfile to include LogicApps bundle

### DIFF
--- a/host/base/host.DockerFIle
+++ b/host/base/host.DockerFIle
@@ -4,9 +4,11 @@ ARG JDK_NAME=jdk8u362-b09
 ARG JAVA_HOME=/usr/lib/jvm/adoptium-8-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
+ARG EXTENSION_BUNDLE_VERSION
 ARG JAVA_VERSION
 ARG JDK_NAME
 ARG JAVA_HOME
+ARG EXTENSION_BUNDLE_CDN_URL=https://functionscdn.azureedge.net/public
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
@@ -20,13 +22,12 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
 
 RUN apt-get update && \
     apt-get install -y gnupg wget unzip && \
-    EXTENSION_BUNDLE_VERSION_V4=4.9.0 && \
-    EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V4}_linux-x64.zip && \
-    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4/$EXTENSION_BUNDLE_FILENAME_V4 && \
-    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4 && \
-    unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4 && \
+    EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.Workflows.${EXTENSION_BUNDLE_VERSION}_any-any.zip && \
+    wget $EXTENSION_BUNDLE_CDN_URL/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION/$EXTENSION_BUNDLE_FILENAME_V4 && \
+    mkdir -p /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V4 &&\
-    find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
+    find /home/data/Functions/ExtensionBundles/ -type f -exec chmod 644 {} \;
 
 RUN wget https://github.com/adoptium/temurin8-binaries/releases/download/${JDK_NAME}/OpenJDK8U-jdk_x64_linux_hotspot_${JAVA_VERSION}.tar.gz && \
     mkdir -p ${JAVA_HOME} && \
@@ -50,7 +51,13 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
-    JAVA_HOME=${JAVA_HOME}
+    JAVA_HOME=${JAVA_HOME} \
+    AzureFunctionsJobHost__extensionBundle__id=Microsoft.Azure.Functions.ExtensionBundle.Workflows \
+    AzureFunctionsJobHost__extensionBundle__version=[1.*,2.0.0) \
+    APP_KIND=workflowApp \
+    FUNCTIONS_EXTENSION_VERSION=~4 \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
+    FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED=1 
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \
@@ -74,7 +81,7 @@ COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 COPY --from=runtime-image [ "${JAVA_HOME}", "${JAVA_HOME}" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY --from=runtime-image [ "/home/data/Functions/ExtensionBundles", "/home/data/Functions/ExtensionBundles" ]
 COPY --from=aspnet6 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/base/host.DockerFIle
+++ b/host/base/host.DockerFIle
@@ -12,6 +12,32 @@ ARG EXTENSION_BUNDLE_CDN_URL=https://functionscdn.azureedge.net/public
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
+RUN if [ "$EXTENSION_BUNDLE_CDN_URL" != "https://functionscdn.azureedge.net/public" ] && [ -z "$EXTENSION_BUNDLE_VERSION" ]; then \
+        echo 'Error: EXTENSION_BUNDLE_VERSION must be set when EXTENSION_BUNDLE_CDN_URL is not "https://functionscdn.azureedge.net/public"' && exit 1; \
+    fi
+
+RUN apt-get update && apt-get install -y curl jq gnupg wget unzip
+RUN curl -o response.json "${EXTENSION_BUNDLE_CDN_URL}/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/index.json"
+
+RUN if [ -z "$EXTENSION_BUNDLE_VERSION" ]; then \
+        EXTENSION_BUNDLE_VERSION=$(jq -r 'max_by(. | split(".") | map(tonumber))' response.json); \
+        echo "Using version: $EXTENSION_BUNDLE_VERSION"; \
+        EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.Workflows.${EXTENSION_BUNDLE_VERSION}_any-any.zip; \
+        wget $EXTENSION_BUNDLE_CDN_URL/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION/$EXTENSION_BUNDLE_FILENAME_V4; \
+        mkdir -p /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        rm -f /$EXTENSION_BUNDLE_FILENAME_V4; \
+    else \
+        echo "Using version: $EXTENSION_BUNDLE_VERSION"; \
+        EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.Workflows.${EXTENSION_BUNDLE_VERSION}_any-any.zip; \
+        wget $EXTENSION_BUNDLE_CDN_URL/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION/$EXTENSION_BUNDLE_FILENAME_V4; \
+        mkdir -p /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        rm -f /$EXTENSION_BUNDLE_FILENAME_V4; \
+    fi
+
+RUN find /home/data/Functions/ExtensionBundles/ -type f -exec chmod 644 {} \;
+
 RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
@@ -19,15 +45,6 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
-
-RUN apt-get update && \
-    apt-get install -y gnupg wget unzip && \
-    EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.Workflows.${EXTENSION_BUNDLE_VERSION}_any-any.zip && \
-    wget $EXTENSION_BUNDLE_CDN_URL/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION/$EXTENSION_BUNDLE_FILENAME_V4 && \
-    mkdir -p /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION && \
-    unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION && \
-    rm -f /$EXTENSION_BUNDLE_FILENAME_V4 &&\
-    find /home/data/Functions/ExtensionBundles/ -type f -exec chmod 644 {} \;
 
 RUN wget https://github.com/adoptium/temurin8-binaries/releases/download/${JDK_NAME}/OpenJDK8U-jdk_x64_linux_hotspot_${JAVA_VERSION}.tar.gz && \
     mkdir -p ${JAVA_HOME} && \

--- a/host/base/host.DockerFIle
+++ b/host/base/host.DockerFIle
@@ -92,7 +92,7 @@ RUN apt-get install -y ca-certificates fonts-liberation libasound2 libatk-bridge
     libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
     libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
 
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 6.0 -Runtime dotnet -InstallDir /usr/share/dotnet \
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 8.0 -Runtime dotnet -InstallDir /usr/share/dotnet \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]

--- a/host/base/host.DockerFIle
+++ b/host/base/host.DockerFIle
@@ -24,19 +24,19 @@ RUN if [ -z "$EXTENSION_BUNDLE_VERSION" ]; then \
         echo "Using version: $EXTENSION_BUNDLE_VERSION"; \
         EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.Workflows.${EXTENSION_BUNDLE_VERSION}_any-any.zip; \
         wget $EXTENSION_BUNDLE_CDN_URL/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION/$EXTENSION_BUNDLE_FILENAME_V4; \
-        mkdir -p /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
-        unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
         rm -f /$EXTENSION_BUNDLE_FILENAME_V4; \
     else \
         echo "Using version: $EXTENSION_BUNDLE_VERSION"; \
         EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.Workflows.${EXTENSION_BUNDLE_VERSION}_any-any.zip; \
         wget $EXTENSION_BUNDLE_CDN_URL/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION/$EXTENSION_BUNDLE_FILENAME_V4; \
-        mkdir -p /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
-        unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /home/data/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
+        unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle.Workflows/$EXTENSION_BUNDLE_VERSION; \
         rm -f /$EXTENSION_BUNDLE_FILENAME_V4; \
     fi
 
-RUN find /home/data/Functions/ExtensionBundles/ -type f -exec chmod 644 {} \;
+RUN find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
@@ -99,7 +99,7 @@ COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 COPY --from=runtime-image [ "${JAVA_HOME}", "${JAVA_HOME}" ]
-COPY --from=runtime-image [ "/home/data/Functions/ExtensionBundles", "/home/data/Functions/ExtensionBundles" ]
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=aspnet6 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/base/host.DockerFIle
+++ b/host/base/host.DockerFIle
@@ -74,7 +74,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     APP_KIND=workflowApp \
     FUNCTIONS_EXTENSION_VERSION=~4 \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
-    FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED=1 
+    FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED=1 \
+    MANAGED_ENVIRONMENT=true 
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \


### PR DESCRIPTION
Sample Docker build commands

`docker build --build-arg HOST_VERSION=4.28.3 -t repo/image:tag .`

`docker build --build-arg HOST_VERSION=4.28.3 --build-arg EXTENSION_BUNDLE_VERSION=1.66.8 -t repo/image:tag .`

`docker build --build-arg EXTENSION_BUNDLE_CDN_URL=https://cdnforlogicappsv2.blob.core.windows.net/logicapps-ishank --build-arg HOST_VERSION=4.28.3 --build-arg EXTENSION_BUNDLE_VERSION=1.72.0.14 -t repo/image:tag .`

